### PR TITLE
MaterialGroup score based on id

### DIFF
--- a/e2e-test/test-requests/item.json
+++ b/e2e-test/test-requests/item.json
@@ -8,11 +8,11 @@
   "materials": [
     {
       "id": 0,
-      "percent": 0.60
+      "percent": 60
     },
     {
       "id": 1,
-      "percent": 0.40
+      "percent": 40
     }
   ],
   "garmentWeight": 12,

--- a/sustaina-index/core/src/main/scala/com/sustainasearch/services/sustainaindex/clothes/SustainaIndexCalculator.scala
+++ b/sustaina-index/core/src/main/scala/com/sustainasearch/services/sustainaindex/clothes/SustainaIndexCalculator.scala
@@ -37,7 +37,7 @@ class SustainaIndexCalculator @Inject()(implicit ec: ExecutionContext) {
   def calculateMaterialPoints(input: SustainaIndexInput, weight: Float): Float = {
 	var materialPoints = 0.0F
 	for ( material <- input.item.materials ) {
-		materialPoints += 0.01F* material.percent * material.materialType.materialGroup.score
+		materialPoints += 0.01F* material.percent * material.materialType.group.score
 	} 
 	materialPoints * weight
   }

--- a/sustaina-index/core/src/main/scala/com/sustainasearch/services/sustainaindex/clothes/material/InMemoryMaterialGroupRepository.scala
+++ b/sustaina-index/core/src/main/scala/com/sustainasearch/services/sustainaindex/clothes/material/InMemoryMaterialGroupRepository.scala
@@ -18,66 +18,31 @@ class InMemoryMaterialGroupRepository @Inject()(implicit ec: ExecutionContext) e
 }
 
 private object MaterialGroupStorage extends Enumeration {
+  private val MaxGroup = 10
+  private val MaxPoints = 100
 
-  case class Val(
-                  override val id: Int,
-                  score: Int
-                ) extends super.Val(id) {
+  case class Val(override val id: Int) extends super.Val(id) {
+    // TODO: why not only pow2?
+    lazy val score: Int = (MaxPoints * pow2(id)) / pow2(MaxGroup)
+
+    private def pow2(x: Int): Int = math.pow(x, 2).toInt
 
     def toMaterialGroup: MaterialGroup = MaterialGroup(id, score)
 
   }
 
   implicit def valueToMaterialGroupVal(x: Value): MaterialGroupStorage.Val = x.asInstanceOf[Val]
-  val MAX_GROUP = 10
-  val MAX_POINTS = 100
 
-  // use materal fx X^2
-  def getScore(x: Int): Int = MAX_POINTS * (x * x) / (MAX_GROUP*MAX_GROUP)
-  
-  val group0 = Val(
-    id = nextId,
-    score = getScore(0)
-  )
-  val group1 = Val(
-    id = nextId,
-    score = getScore(1)
-  )
-  val group2 = Val(
-    id = nextId,
-    score = getScore(2)
-  )
-  val group3 = Val(
-    id = nextId,
-    score = getScore(3)
-  )
-  val group4 = Val(
-    id = nextId,
-    score = getScore(4)
-  )
-  val group5 = Val(
-    id = nextId,
-    score = getScore(5)
-  )
-  val group6 = Val(
-    id = nextId,
-    score = getScore(6)
-  )
-  val group7 = Val(
-    id = nextId,
-    score = getScore(7)
-  )
-  val group8 = Val(
-    id = nextId,
-    score = getScore(8)
-  )
-  val group9 = Val(
-    id = nextId,
-    score = getScore(9)
-  )
-  val group10 = Val(
-    id = nextId,
-    score = getScore(10)
-  )
-  
+  val group0 = Val(id = nextId)
+  val group1 = Val(id = nextId)
+  val group2 = Val(id = nextId)
+  val group3 = Val(id = nextId)
+  val group4 = Val(id = nextId)
+  val group5 = Val(id = nextId)
+  val group6 = Val(id = nextId)
+  val group7 = Val(id = nextId)
+  val group8 = Val(id = nextId)
+  val group9 = Val(id = nextId)
+  val group10 = Val(id = nextId)
+
 }

--- a/sustaina-index/core/src/test/scala/com/sustainasearch/services/sustainaindex/clothes/SustainaIndexCalculatorTest.scala
+++ b/sustaina-index/core/src/test/scala/com/sustainasearch/services/sustainaindex/clothes/SustainaIndexCalculatorTest.scala
@@ -1,24 +1,31 @@
 package com.sustainasearch.services.sustainaindex.clothes
 
+import com.sustainasearch.services.sustainaindex.certification.InMemoryCertificationRepository
+import com.sustainasearch.services.sustainaindex.clothes.material.{Material, MaterialGroup, MaterialType}
+import com.sustainasearch.services.sustainaindex.country.Country
 import com.sustainasearch.services.sustainaindex.{SustainaIndex, Tenant}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{Matchers, WordSpec}
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 import scala.util.Success
 
 class SustainaIndexCalculatorTest extends WordSpec with Matchers with ScalaFutures {
   val underTest = new SustainaIndexCalculator()
 
   classOf[SustainaIndexCalculator].getSimpleName should {
-    "calculate sustaina index for clothes" in {
-
-	// Test country
+    "calculate sustaina index for clothes with country" in {
+      val country = Country(
+        countryCode = "SE",
+        renewableEnergy = 53.25F,
+        crc = 95.0F
+      )
       val input = SustainaIndexInput(
         tenant = Tenant(id = "1", host = "host_1"),
         item = Item(
           id = "pid1",
-          country = Option(Country.withCountryCode("SE")),
+          country = Option(country),
           certifications = Seq.empty,
           materials = Seq.empty,
           garmentWeight = None,
@@ -29,43 +36,64 @@ class SustainaIndexCalculatorTest extends WordSpec with Matchers with ScalaFutur
       whenReady(eventualResult) { result =>
         result shouldBe Success(SustainaIndex(0.2015F))
       }
+    }
 
-	  // Test certification
-	  val input = SustainaIndexInput(
-        tenant = Tenant(id = "1", host = "host_1"),
-        item = Item(
-          id = "pid1",
-          country = None,
-          certifications = Seq(Certification.withId(0), Certification.withId(1)),
-          materials = Seq.empty,
-          garmentWeight = None,
-          brand = None
+    "calculate sustaina index for clothes with certification" in {
+      val certificationRepository = new InMemoryCertificationRepository()
+      val cert0F = certificationRepository.getCertification(0).map(_.get)
+      val cert1F = certificationRepository.getCertification(1).map(_.get)
+      val certsF = Future.sequence(Seq(cert0F, cert1F))
+
+      whenReady(certsF) { certs =>
+        val input = SustainaIndexInput(
+          tenant = Tenant(id = "1", host = "host_1"),
+          item = Item(
+            id = "pid1",
+            country = None,
+            certifications = certs,
+            materials = Seq.empty,
+            garmentWeight = None,
+            brand = None
+          )
         )
-      )
-      val eventualResult = underTest.calculateSustainaIndex(input)
-      whenReady(eventualResult) { result =>
-        result shouldBe Success(SustainaIndex(0.21F))
+        val eventualResult = underTest.calculateSustainaIndex(input)
+        whenReady(eventualResult) { result =>
+          result shouldBe Success(SustainaIndex(0.21F))
+        }
       }
+    }
 
-	// Test certification
-	  val input = SustainaIndexInput(
+    "calculate sustaina index for clothes with material" in {
+      val material = Material(
+        materialType = MaterialType(
+          id = 1,
+          group = MaterialGroup(
+            id = 10,
+            score = 100F
+          )
+        ),
+        percent = 100F
+      )
+      val input = SustainaIndexInput(
         tenant = Tenant(id = "1", host = "host_1"),
         item = Item(
           id = "pid1",
           country = None,
           certifications = Seq.empty,
-          materials = Seq(Material(MaterialType(1), 1.0F)),
+          materials = Seq(material),
           garmentWeight = None,
           brand = None
         )
       )
       val eventualResult = underTest.calculateSustainaIndex(input)
       whenReady(eventualResult) { result =>
-        result shouldBe Success(SustainaIndex(0.4F))
+        result shouldBe Success(SustainaIndex(0.39999998F))
       }
 
-	  // Test empty
-	  val input = SustainaIndexInput(
+    }
+
+    "calculate sustaina index for clothes with empty input" in {
+      val input = SustainaIndexInput(
         tenant = Tenant(id = "1", host = "host_1"),
         item = Item(
           id = "pid1",

--- a/sustaina-index/core/src/test/scala/com/sustainasearch/services/sustainaindex/clothes/material/InMemoryMaterialGroupStorageTest.scala
+++ b/sustaina-index/core/src/test/scala/com/sustainasearch/services/sustainaindex/clothes/material/InMemoryMaterialGroupStorageTest.scala
@@ -13,6 +13,15 @@ class InMemoryMaterialGroupStorageTest extends WordSpec with Matchers {
 
     "provide score" in {
       MaterialGroupStorage.group0.score shouldBe 0
+      MaterialGroupStorage.group1.score shouldBe 1
+      MaterialGroupStorage.group2.score shouldBe 4
+      MaterialGroupStorage.group3.score shouldBe 9
+      MaterialGroupStorage.group4.score shouldBe 16
+      MaterialGroupStorage.group5.score shouldBe 25
+      MaterialGroupStorage.group6.score shouldBe 36
+      MaterialGroupStorage.group7.score shouldBe 49
+      MaterialGroupStorage.group8.score shouldBe 64
+      MaterialGroupStorage.group9.score shouldBe 81
       MaterialGroupStorage.group10.score shouldBe 100
     }
   }

--- a/sustaina-index/model/src/main/scala/com/sustainasearch/services/sustainaindex/clothes/material/MaterialType.scala
+++ b/sustaina-index/model/src/main/scala/com/sustainasearch/services/sustainaindex/clothes/material/MaterialType.scala
@@ -1,3 +1,3 @@
 package com.sustainasearch.services.sustainaindex.clothes.material
 
-case class MaterialType(id: Int, materialGroup: MaterialGroup)
+case class MaterialType(id: Int, group: MaterialGroup)


### PR DESCRIPTION
Har fixat så att `score` i `MaterialGroupStorage.Val` nu räknas fram baserat på group ID (istället för hårdkodat).
Hade vi inte kunna förenkla hur det räknas fram så att det bara är `id^2`?

Har också fixat så att `SustainaIndexCalculatorTest` kompilerar. Kolla gärna lite extra så att de olika resultaten är de förväntade.